### PR TITLE
Expose `client_class` option to configure redis.

### DIFF
--- a/lib/async/job/backend/redis.rb
+++ b/lib/async/job/backend/redis.rb
@@ -10,8 +10,8 @@ module Async
 	module Job
 		module Backend
 			module Redis
-				def self.new(delegate, endpoint: Async::Redis.local_endpoint, **options)
-					client = Async::Redis::Client.new(endpoint)
+				def self.new(delegate, endpoint: Async::Redis.local_endpoint, client_class: Async::Redis::Client, **options)
+					client = client_class.new(endpoint)
 					return Server.new(delegate, client, **options)
 				end
 			end

--- a/lib/async/job/backend/redis.rb
+++ b/lib/async/job/backend/redis.rb
@@ -10,8 +10,16 @@ module Async
 	module Job
 		module Backend
 			module Redis
-				def self.new(delegate, endpoint: Async::Redis.local_endpoint, client_class: Async::Redis::Client, **options)
-					client = client_class.new(endpoint)
+				# A simple server that processes jobs from a Redis backend.
+				#
+				# @parameter delegate [Object] The object that will be called with the job data.
+				# @parameter endpoint [Async::IO::Endpoint] The Redis endpoint to connect to.
+				# @parameter protocol [Async::Redis::Protocol] The Redis protocol to use.
+				# @parameter options [Hash] Additional options passed to the server.
+				def self.new(delegate, endpoint: Async::Redis.local_endpoint, protocol: nil, **options)
+					client_options = {protocol: protocol}.compact
+					
+					client = Async::Redis::Client.new(endpoint, **client_options)
 					return Server.new(delegate, client, **options)
 				end
 			end


### PR DESCRIPTION
Possibly a fix for <https://github.com/socketry/async-job-processor-redis/issues/1>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
