### PR TITLE
update inline processor example to use current API

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -44,6 +44,7 @@ sequenceDiagram
 You can use {ruby Async::Job::Builder} to create a pipeline that includes both the producer and consumer sides of a queue:
 
 ```ruby
+require 'async'
 require 'async/job'
 require 'async/job/processor/inline'
 
@@ -54,13 +55,13 @@ end
 
 # Create a simple inline pipeline:
 pipeline = Async::Job::Builder.build(executor) do
-	# We are going to use an inline queue which processes the job in the background using Async{}:
-	queue Async::Job::Queue::Inline
+	# We are going to use an inline processor which processes the job in the background using Async{}:
+	enqueue Async::Job::Processor::Inline
 end
 
 # Enqueue a job:
 Async do
-	pipeline.client.call("My job")
+	pipeline.call("My job")
 	# Prints "Processing job: My job"
 end
 ```


### PR DESCRIPTION
The "Getting Started" example was using queue with Async::Job::Queue::Inline, but that API changed and doesn’t work in recent versions. Could confuse new users (like me xD).

Switched it to use enqueue with Async::Job::Processor::Inline, added the missing require 'async', and simplified the client call. Now the guide is correct and the example actually works.

## Types of Changes

- Bug fix.
- Maintenance.

## Contribution

- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
